### PR TITLE
header: add {$packrecords c}

### DIFF
--- a/source/framework_loader.php
+++ b/source/framework_loader.php
@@ -281,6 +281,7 @@ class FrameworkLoader {
 		$output->writeln(0, "{\$mode delphi}");
 		$output->writeln(0, "{\$modeswitch objectivec1}");
 		$output->writeln(0, "{\$modeswitch cvar}");
+		$output->writeln(0, "{\$packrecords c}");
 		$output->writeln(0, "");
 
 		$output->writeln(0, "unit ".TEMPLATE_FILE_DEFINED_CLASSES.$framework->get_name().";");


### PR DESCRIPTION
All structs/records in (Objective-)C headers use C record alignment rules by default.