### PR TITLE
bitfields: support space after bitfield width

### DIFF
--- a/source/parser_field.php
+++ b/source/parser_field.php
@@ -146,7 +146,7 @@ class HeaderFieldParser extends HeaderParserModule {
 		$field->contents = $scope->contents;
 		
 		// bit field
-		if (preg_match("/:\s*(\d+)$/", $scope->results[3], $captures)) {
+		if (preg_match("/:\s*(\d+)\s*$/", $scope->results[3], $captures)) {
 			$field->bit_field = (int)$captures[1];
 		}
 		


### PR DESCRIPTION
This can happen if the bitfield width was followed by a removed macro, like
in NSImageRep.h